### PR TITLE
Simplified views validation, code tweaks.

### DIFF
--- a/css/masonry_gallery.css
+++ b/css/masonry_gallery.css
@@ -39,6 +39,17 @@
   opacity: 1;
 }
 
+/* hide hovering captions on small and touch screens */
+@media only screen and (max-width: 62em), (any-hover: none) {
+  .masonry-gallery-caption.hover {
+    display: none;
+  }
+}
+
+.masonry-gallery-caption:empty{
+  visibility: hidden;
+}
+
 .masonry-gallery-caption > *{
   display: block;
   margin: auto 0;

--- a/css/masonry_gallery.css
+++ b/css/masonry_gallery.css
@@ -20,8 +20,7 @@
 .masonry-gallery-caption {
   display: block;
   box-sizing: border-box;
-  line-height: 1;
-  padding: 0.5em;
+  padding: 0.75em;
   overflow: hidden;
   z-index: 10;
   background-color: transparent;

--- a/js/masonry_gallery_lib.js
+++ b/js/masonry_gallery_lib.js
@@ -87,6 +87,7 @@ function MasonryGallery(newSettings) {
           minColumn = c;
         }
       });
+
       // Add item height to the column with minimal height.
       let itemHeight = columnWidth/ratio[i] + settings.captionHeight + settings.gap;
       columnHeight[minColumn] += itemHeight;

--- a/masonry_gallery.install
+++ b/masonry_gallery.install
@@ -26,7 +26,7 @@ function masonry_gallery_disable() {
       'type'  => 'ul',
     );
     $message = t('The following Views displays are using the Masonry Gallery plugin, which is no longer enabled. It is recommended that you update these displays, otherwise they will not work properly. Links open in a new window.');
-    $message .= theme ('item_list', $variables);
+    $message .= theme('item_list', $variables);
     backdrop_set_message($message, 'warning');
   }
 }

--- a/masonry_gallery.module
+++ b/masonry_gallery.module
@@ -186,7 +186,7 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
               $text_field_name = $options['caption']['source'];
               $text = $style_plugin->get_field($i, $text_field_name);
               // If text is not html then wrap it in <p> tags. This is required for proper styling.
-              if ($text == strip_tags($text)) {
+              if ($text == strip_tags($text) && !empty($text)) {
                 $text = '<p>' . $text . '</p>';
               }
               $captions[$i] = $text;

--- a/masonry_gallery.module
+++ b/masonry_gallery.module
@@ -168,13 +168,13 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
 
         // If caption source is set then store captions.
         switch ($options['caption']['source']) {
-          case 'alt':
+          case 'alt_tag':
             $alt_value = $image_field_value[0]['alt'];
             if (isset($alt_value) && $alt_value != '') {
               $captions[$i] = '<p>' . $alt_value . '</p>';
             }
             break;
-          case 'title':
+          case 'title_tag':
             $title_value = $image_field_value[0]['title'];
             if (!empty($title_value)) {
               $captions[$i] = '<p>' . $title_value . '</p>';

--- a/masonry_gallery.module
+++ b/masonry_gallery.module
@@ -116,10 +116,11 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
   $config  = config('masonry_gallery.settings');
   $options = $vars['options'];
 
-  // Find names of the image and body fields handlers.
-  // These are needed to retrieve fields raw and rendered data.
+  // Find name of the image field handler.
+  // It is needed to retrieve fields raw and rendered data.
   $image_field_name = $style_plugin->get_first_non_excluded_image_field()['field_name'];
-  $text_field_name  = $style_plugin->get_first_non_excluded_text_field()['field_name'];
+  // Get list of valid text fields.
+  $text_fields = $style_plugin->get_non_excluded_text_fields();
 
   // Get and process all the required data for image display.
   if (isset($image_field_name)) {
@@ -179,9 +180,10 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
               $captions[$i] = '<p>' . $title_value . '</p>';
             }
             break;
-          case 'text':
-            if (isset($text_field_name)) {
+          default:
+            if (!empty($text_fields)) {
               // Get text field as caption.
+              $text_field_name = $options['caption']['source'];
               $text = $style_plugin->get_field($i, $text_field_name);
               // If text is not html then wrap it in <p> tags. This is required for proper styling.
               if ($text == strip_tags($text)) {
@@ -189,7 +191,6 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
               }
               $captions[$i] = $text;
             }
-            break;
         }
       }
       elseif (empty($options['hide_empty'])) {

--- a/masonry_gallery.module
+++ b/masonry_gallery.module
@@ -81,9 +81,9 @@ function masonry_gallery_config_info() {
  * Displays warning about styles in preview mode.
 }*/
 function masonry_gallery_views_pre_render(&$view) {
-  if (isset($view->preview)) {
+  if (isset($view->live_preview)) {
     $options = $view->style_plugin->options;
-    if (!empty($options['captions']['source'])) {
+    if (!empty($options['caption']['source'])) {
       // Get deafault and views theme names.
       $default_theme_name = config_get('system.core', 'theme_default');
       $views_theme_name = config_get('views_ui.settings', 'custom_theme');
@@ -127,7 +127,7 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
     $images_rendered = array();
     $images_ratio    = array();
     $captions = empty($options['caption']['source']) ? NULL : array();
-    
+
     // Set caption class depending on caption display option.
     switch ($options['caption']['display']) {
       case 'static':
@@ -154,14 +154,14 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
       // image field has a single value.
       $width  = $image_field_value[0]['width'];
       $height = $image_field_value[0]['height'];
-      
+
       // Check that image width and height are not zero.
       // Zero height/width may indicate that image file is missing.
       if ($width > 0 && $height > 0) {
         // Calculate image width and height ratio. It will be used
         // for gallery arrangement via javascript.
         $images_ratio[$i] = $width/$height;
-        
+
         // Store rendered image field.
         $images_rendered[$i] = $style_plugin->get_field($i, $image_field_name);
 
@@ -209,7 +209,7 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
 
   // Create unique id for the masonry gallery.
   $masonry_id = 'masonry-gallery-' . $view->name . '-' . $view->current_display;
-  
+
   $vars['masonry_id']      = $masonry_id;
   $vars['images_rendered'] = $images_rendered;
   $vars['captions']        = $captions;
@@ -265,7 +265,7 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
   // The rest of the function code below generates customized CSS, based on
   // configuration, and module options.
   $custom_css = '';
-  
+
   // If columns number is set to auto, then extrapolate columns number
   // for each screen(breakpoint) between desktop value and 1(phone).
   if ($options['columns']['auto']) {
@@ -296,7 +296,7 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
         $options['columns']['smartphone'] = intval(ceil($options['columns']['desktop'] * 0.25));
     }
   }
-  
+
   // Create gallery style based on columns settings.
   $custom_css .= "
     #{$masonry_id}.masonry-gallery {
@@ -348,8 +348,8 @@ function template_preprocess_views_view_masonry_gallery(&$vars) {
 
   // Check loader style setting.
   $loader_style = $config->get('loader_style');
+
   // If one of the loader styles selected then add it's CSS file.
-  
   if (!empty($loader_style)) {
     backdrop_add_css($module_dir . '/css/masonry_gallery_loader_' . $loader_style . '.css');
 

--- a/masonry_gallery.views.inc
+++ b/masonry_gallery.views.inc
@@ -9,7 +9,7 @@
  */
 function masonry_gallery_views_plugins() {
   $module_path = backdrop_get_path('module', 'masonry_gallery');
-  
+
   return array(
     'style' => array(
       'masonry_gallery' => array(

--- a/views-view-masonry-gallery.tpl.php
+++ b/views-view-masonry-gallery.tpl.php
@@ -31,10 +31,8 @@
         <?php if(!empty($loader)):?>
           <div class="masonry-gallery-loader"></div>
         <?php endif ?>
-        <?php if(!empty($captions[$i])): ?>
-          <div<?php if(!empty($caption_class)): print(' class="' . $caption_class . '"'); endif;?>>
-            <?php print $captions[$i] ?>
-          </div>
+        <?php if(isset($captions[$i])): ?>
+          <div<?php if(!empty($caption_class)): print(' class="' . $caption_class . '"'); endif; print('>' . $captions[$i]); ?></div>
         <?php endif ?>
       <?php endif ?>
     </div>

--- a/views-view-masonry-gallery.tpl.php
+++ b/views-view-masonry-gallery.tpl.php
@@ -13,7 +13,7 @@
  */
 ?>
 
-<?php if(isset($view->preview)): ?>
+<?php if(isset($view->live_preview)): ?>
 <style>
 <?php print $custom_css;?>
 </style>

--- a/views_plugin_style_masonry_gallery.inc
+++ b/views_plugin_style_masonry_gallery.inc
@@ -298,7 +298,6 @@ class views_plugin_style_masonry_gallery extends views_plugin_style {
       }
 
       if ($field_valid) {
-        //$result[] = array('handler' => $field, 'field_name' => $field_name);
         $result[$field_name] = $field;
       }
     }

--- a/views_plugin_style_masonry_gallery.inc
+++ b/views_plugin_style_masonry_gallery.inc
@@ -149,8 +149,8 @@ class views_plugin_style_masonry_gallery extends views_plugin_style {
 
     // Set options list for caption selector.
     $caption_options = array(
-      'alt'        => t('Image alt tag'),
-      'title'      => t('Image title tag'),
+      'alt_tag'        => t('Image alt tag'),
+      'title_tag'      => t('Image title tag'),
     );
     // Detect if valid text fields are present, and add them to the options list.
     $text_fields = $this->get_non_excluded_text_fields();

--- a/views_plugin_style_masonry_gallery.inc
+++ b/views_plugin_style_masonry_gallery.inc
@@ -307,8 +307,8 @@ class views_plugin_style_masonry_gallery extends views_plugin_style {
 
   /**
    * Validates the view configuration.
-   * Fails if there is a non-image or non-text field, or there are more
-   * than one image and text fields that are not excluded from display.
+   * Fails if there is no image field, or there is no text field in
+   * case it is set as caption source in the plugin settings.
    */
   function validate() {
     $errors = parent::validate();
@@ -319,57 +319,19 @@ class views_plugin_style_masonry_gallery extends views_plugin_style {
       return $errors;
     }
 
-    // Get a list of fields that have been added to the display.
-    $fields = $this->display->handler->get_handlers('field');
-
-    $image_field_count = 0;
-    $text_field_count  = 0;
-
-    foreach ($fields as $field_name => $field) {
-      // Ignore fields excluded from display.
-      if (!empty($field->options['exclude'])) {
-        continue;
-      }
-
-      // Check field type.
-      if (isset($field->field_info['type'])) {
-        $field_type = $field->field_info['type'];
-      }
-      elseif ($field->field == 'title') {
-        $field_type = 'title';
-      }
-      $is_image = $field_type == 'image';
-      $is_text = in_array($field_type, $this->get_text_field_types());
-      $is_title = $field_name == 'title';
-
-      // If invalid field type found then validation failed.
-      if (!$is_image && !$is_text && !$is_title) {
-        $errors[] = t('Invalid field types found. This format requires one image field, and may optionally have one text or title field.');
-        return $errors;
-      }
-
-      // Count valid fields.
-      if ($is_image) {
-        $image_field_count ++;
-      }
-      if ($is_text || $is_title) {
-        $text_field_count++;
-      }
-
-      // Check if there is no more than one of each valid field types.
-      if ($image_field_count > 1) {
-        $errors[] = t('There is more than one image field. This format can display only one image field.');
-        break;
-      }
-      if ($text_field_count > 1) {
-        $errors[] = t('There is more than one text field. This format can display only one text or title field.');
-        break;
-      }
+    // Check if there is an image field in the fields list.
+    $image_field = $this->get_first_non_excluded_image_field();
+    if (empty($image_field)) {
+      $errors[] = t('Image field is not found or excluded from display. @title format requires one image field.', array('@title' => $this->plugin_title()));
     }
 
-    // Check if there is at least one image field.
-    if ($image_field_count < 1) {
-      $errors[] = t('There are no image fields. This format requires at least one image field.');
+    // Check if there is a text field in the fields list in case text field is set as caption source.
+    $caption_source = $this->options['caption']['source'];
+    if (!empty($caption_source) && $caption_source != 'alt' && $caption_source != 'title') {
+      $text_field = $this->get_first_non_excluded_text_field()['handler'];
+      if (empty($text_field)) {
+        $errors[] = t('A text field is set as caption source in @title format settings but is either not present or hidden in the fields list.', array('@title' => $this->plugin_title()));
+      }
     }
 
     return $errors;

--- a/views_plugin_style_masonry_gallery.inc
+++ b/views_plugin_style_masonry_gallery.inc
@@ -152,10 +152,12 @@ class views_plugin_style_masonry_gallery extends views_plugin_style {
       'alt'        => t('Image alt tag'),
       'title'      => t('Image title tag'),
     );
-    // Detect if text or title field is present, and add it to the options list.
-    $text_field = $this->get_first_non_excluded_text_field()['handler'];
-    if (!empty($text_field)) {
-      $caption_options['text'] = $text_field->ui_name();
+    // Detect if valid text fields are present, and add them to the options list.
+    $text_fields = $this->get_non_excluded_text_fields();
+    if (!empty($text_fields)) {
+      foreach ($text_fields as $field_name => $text_field) {
+        $caption_options[$field_name] = $text_field->ui_name();
+      }
     }
     // Create caption selector form.
     $form['caption']['source'] = array(
@@ -246,11 +248,10 @@ class views_plugin_style_masonry_gallery extends views_plugin_style {
   }
 
   /**
-   * Returns first non-excluded field by type.
-   * Returned value is an array containing handler and field's name. Works only
-   * for views_handler_field_field types that have field_info and for title fields.
+   * Returns first non-excluded image field.
+   * Returned value is an array containing handler and field's name.
    */
-  protected function get_first_non_excluded_field(string $field_type) {
+  function get_first_non_excluded_image_field() {
     $fields = $this->view->display_handler->get_handlers('field');
 
     foreach ($fields as $field_name => $field) {
@@ -258,44 +259,50 @@ class views_plugin_style_masonry_gallery extends views_plugin_style {
       if (!empty($field->options['exclude']))
         continue;
 
-      if (isset($field->field_info) || $field_type == 'title') {
-        $type = FALSE;
-        if (!empty($field->field_info['type'])) {
-          $type = $field->field_info['type'];
-        }
-        // If it is of required type, return field handler and field name.
-        // Title has no field_info, so add a second condition.
-        if ($field_type == $type || ($field_type == 'title' && $field_name == 'title')) {
+      if (isset($field->field_info)) {
+        $type = empty($field->field_info['type']) ? NULL : $field->field_info['type'];
+        // If it is of image type, return field handler and field name.
+        if ($type == 'image') {
           return array('handler' => $field, 'field_name' => $field_name);
         }
       }
-
     }
     return NULL;
   }
 
-  /*
-   * Returns first non excluded image field.
+  /**
+   * Returns all valid non-excluded text fields.
+   * Returned value is an array containing (field's name => handler) pairs.
    */
-  function get_first_non_excluded_image_field() {
-    return $this->get_first_non_excluded_field('image');
-  }
+  function get_non_excluded_text_fields() {
+    $fields = $this->view->display_handler->get_handlers('field');
 
-  /*
-   * Returns first non excluded text field.
-   */
-  function get_first_non_excluded_text_field() {
-    // Set possible text field types.
-    $text_types = $this->get_text_field_types();
-    // Search for each possible type of text field.
-    foreach ($text_types as $text_type) {
-      $field_data = $this->get_first_non_excluded_field($text_type);
-      // Return the fist text field found.
-      if (!empty($field_data)) {
-        return $field_data;
+    $result = array();
+    foreach ($fields as $field_name => $field) {
+      // Ignore excluded fields.
+      if (!empty($field->options['exclude']))
+        continue;
+
+      $field_valid = FALSE;
+      if (isset($field->field_info)) {
+        $type = empty($field->field_info['type']) ? NULL : $field->field_info['type'];
+        // Consider valid if it is of any text type.
+        if (in_array($type, $this->get_text_field_types())) {
+          $field_valid = TRUE;
+        }
+      }
+      // Consider valid if names start with 'title' and 'nothing'.
+      // These correspond to Content:title and Global: Custom text.
+      elseif (substr($field_name, 0, 5) == 'title' || substr($field_name, 0, 7) == 'nothing') {
+        $field_valid = TRUE;
+      }
+
+      if ($field_valid) {
+        //$result[] = array('handler' => $field, 'field_name' => $field_name);
+        $result[$field_name] = $field;
       }
     }
-    return NULL;
+    return count($result) ? $result : NULL;
   }
 
   /**
@@ -328,8 +335,8 @@ class views_plugin_style_masonry_gallery extends views_plugin_style {
     // Check if there is a text field in the fields list in case text field is set as caption source.
     $caption_source = $this->options['caption']['source'];
     if (!empty($caption_source) && $caption_source != 'alt' && $caption_source != 'title') {
-      $text_field = $this->get_first_non_excluded_text_field()['handler'];
-      if (empty($text_field)) {
+      $text_fields = $this->get_non_excluded_text_fields();
+      if (empty($text_fields)) {
         $errors[] = t('A text field is set as caption source in @title format settings but is either not present or hidden in the fields list.', array('@title' => $this->plugin_title()));
       }
     }


### PR DESCRIPTION
- View style plugin validation has been simplified, requiring just an image field present.
- Caption text source can be almost any non excluded field set in View.
- Empty captions are now hidden.
- Fixed message in views preview mode about admin and default themes.
- Minor code tweaks and clean up.